### PR TITLE
Add doc URLs for our deps to app-web-frontend/README.md

### DIFF
--- a/app-web-frontend/README.md
+++ b/app-web-frontend/README.md
@@ -1,6 +1,23 @@
-# Getting Started with Create React App
+# Emotional-Support App --- Web Front-End
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+
+## Documentation URLs for our stack:
+
+- [@fullcalendar](https://fullcalendar.io/docs)
+- [axios](https://axios-http.com/docs/intro)
+- [bootstrap](https://getbootstrap.com/docs/5.3/getting-started/introduction/)
+- [bootstrap-icons](https://icons.getbootstrap.com/)
+- [bootswatch](https://bootswatch.com/)
+- [emoji-mart](https://www.npmjs.com/package/emoji-mart)
+- [react](https://react.dev/)
+- [react-color](https://casesandberg.github.io/react-color/)
+- [react-dom](https://react.dev/reference/react-dom)
+- [react-router-dom](https://reactrouter.com/en/main)
+- [react-scripts](https://create-react-app.dev/docs/getting-started/)
+- [startbootstrap-sb-admin-2](https://startbootstrap.com/theme/sb-admin-2)
+- [styled-components](https://styled-components.com/docs)
+- [web-vitals](https://www.npmjs.com/package/web-vitals)
 
 ## Available Scripts
 


### PR DESCRIPTION
On behalf of tribe 3 group 1, while working on the task

> 1. Introduction page for our product + Installation instructions (1 person + Lead Marketing, week 2)
Create a README.md file with the description of our app. There should also be included the link to a deployed version, link to all other documentation (on wiki) etc

I added the URLs to documentation of the npm packages we use as dependencies to the frontend-specific README. Some people think this is helpful